### PR TITLE
Fix typo in openapi spec

### DIFF
--- a/docs/License.md
+++ b/docs/License.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LicenceText** | Pointer to **string** |  | [optional] 
+**LicenseText** | **string** |  | 
 **IsValid** | Pointer to **bool** |  | [optional] [readonly] 
 **IsSingleUser** | Pointer to **bool** |  | [optional] [readonly] 
 **SubscriptionId** | Pointer to **string** |  | [optional] [readonly] 
@@ -19,7 +19,7 @@ Name | Type | Description | Notes
 
 ### NewLicense
 
-`func NewLicense() *License`
+`func NewLicense(licenseText string, ) *License`
 
 NewLicense instantiates a new License object
 This constructor will assign default values to properties that have it defined,
@@ -34,30 +34,25 @@ NewLicenseWithDefaults instantiates a new License object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
 
-### GetLicenceText
+### GetLicenseText
 
-`func (o *License) GetLicenceText() string`
+`func (o *License) GetLicenseText() string`
 
-GetLicenceText returns the LicenceText field if non-nil, zero value otherwise.
+GetLicenseText returns the LicenseText field if non-nil, zero value otherwise.
 
-### GetLicenceTextOk
+### GetLicenseTextOk
 
-`func (o *License) GetLicenceTextOk() (*string, bool)`
+`func (o *License) GetLicenseTextOk() (*string, bool)`
 
-GetLicenceTextOk returns a tuple with the LicenceText field if it's non-nil, zero value otherwise
+GetLicenseTextOk returns a tuple with the LicenseText field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetLicenceText
+### SetLicenseText
 
-`func (o *License) SetLicenceText(v string)`
+`func (o *License) SetLicenseText(v string)`
 
-SetLicenceText sets LicenceText field to given value.
+SetLicenseText sets LicenseText field to given value.
 
-### HasLicenceText
-
-`func (o *License) HasLicenceText() bool`
-
-HasLicenceText returns a boolean if a field has been set.
 
 ### GetIsValid
 

--- a/docs/LicensesApi.md
+++ b/docs/LicensesApi.md
@@ -215,7 +215,7 @@ import (
 
 func main() {
     id := "id_example" // string | The id of the license
-    license := *openapiclient.NewLicense() // License |  (optional)
+    license := *openapiclient.NewLicense("LicenseText_example") // License |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)

--- a/model_license.go
+++ b/model_license.go
@@ -16,7 +16,7 @@ import (
 
 // License struct for License
 type License struct {
-	LicenceText *string `json:"LicenceText,omitempty"`
+	LicenseText string `json:"LicenseText"`
 	IsValid *bool `json:"IsValid,omitempty"`
 	IsSingleUser *bool `json:"IsSingleUser,omitempty"`
 	SubscriptionId *string `json:"SubscriptionId,omitempty"`
@@ -32,8 +32,9 @@ type License struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewLicense() *License {
+func NewLicense(licenseText string, ) *License {
 	this := License{}
+	this.LicenseText = licenseText
 	return &this
 }
 
@@ -45,36 +46,28 @@ func NewLicenseWithDefaults() *License {
 	return &this
 }
 
-// GetLicenceText returns the LicenceText field value if set, zero value otherwise.
-func (o *License) GetLicenceText() string {
-	if o == nil || o.LicenceText == nil {
+// GetLicenseText returns the LicenseText field value
+func (o *License) GetLicenseText() string {
+	if o == nil  {
 		var ret string
 		return ret
 	}
-	return *o.LicenceText
+
+	return o.LicenseText
 }
 
-// GetLicenceTextOk returns a tuple with the LicenceText field value if set, nil otherwise
+// GetLicenseTextOk returns a tuple with the LicenseText field value
 // and a boolean to check if the value has been set.
-func (o *License) GetLicenceTextOk() (*string, bool) {
-	if o == nil || o.LicenceText == nil {
+func (o *License) GetLicenseTextOk() (*string, bool) {
+	if o == nil  {
 		return nil, false
 	}
-	return o.LicenceText, true
+	return &o.LicenseText, true
 }
 
-// HasLicenceText returns a boolean if a field has been set.
-func (o *License) HasLicenceText() bool {
-	if o != nil && o.LicenceText != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetLicenceText gets a reference to the given string and assigns it to the LicenceText field.
-func (o *License) SetLicenceText(v string) {
-	o.LicenceText = &v
+// SetLicenseText sets field value
+func (o *License) SetLicenseText(v string) {
+	o.LicenseText = v
 }
 
 // GetIsValid returns the IsValid field value if set, zero value otherwise.
@@ -367,8 +360,8 @@ func (o *License) SetId(v string) {
 
 func (o License) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if o.LicenceText != nil {
-		toSerialize["LicenceText"] = o.LicenceText
+	if true {
+		toSerialize["LicenseText"] = o.LicenseText
 	}
 	if o.IsValid != nil {
 		toSerialize["IsValid"] = o.IsValid

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -908,7 +908,7 @@ components:
     # licenses
     License:
       properties:
-        LicenceText:
+        LicenseText:
           type: string
         IsValid:
           type: boolean


### PR DESCRIPTION
should be "LicenseText", not "LicenceText"